### PR TITLE
misformatted_housenumber_lenient – better regex

### DIFF
--- a/mapserver/addresses.local.map
+++ b/mapserver/addresses.local.map
@@ -943,6 +943,26 @@ MAP
         FILTER ("[houseno]" != '')
         CLASSITEM "houseno"
         CLASS
+            EXPRESSION ('[houseno]' = 'XXXXXXXXX')
+            # This hack is only necessary in order that the preview icons in
+            # OSMI are rendered. They show the first class of a layer.
+            NAME "demo how rendering would look like"
+            STYLE
+                SYMBOL "circle"
+                SIZE 10
+                COLOR 200 0 0
+                ANTIALIAS true
+            END
+            LABEL
+                SIZE 8
+                COLOR 200 0 0
+                OUTLINECOLOR 255 255 255
+                TYPE TRUETYPE
+                FONT "DejaVuSans,unifont"
+                POSITION lc
+            END
+        END
+        CLASS
             # empty class is necessary because the will catch all valid house
             # numbers and only the invalid ones will hit the next class
             EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,2}[ /]?[a-zA-Z]{0,3}([-,]*[1-9][0-9]{0,2}[ /]?[a-zA-Z]{0,3}){0,12}$')

--- a/mapserver/addresses.local.map
+++ b/mapserver/addresses.local.map
@@ -962,11 +962,27 @@ MAP
                 POSITION lc
             END
         END
+        # Empty classes are necessary because they will catch all valid house
+        # numbers and only the invalid ones will hit the next class.
+        # We start with simple regex and continue with more complicated ones
+        # to improve performance (4 instead of 10 seconds on zoom 11 in
+        # Germany).
         CLASS
-            # empty class is necessary because the will catch all valid house
-            # numbers and only the invalid ones will hit the next class
-            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,2}[ /]?[a-zA-Z]{0,3}([-,]*[1-9][0-9]{0,2}[ /]?[a-zA-Z]{0,3}){0,12}$')
-            NAME "valid house numbers"
+            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,4}$')
+            NAME "simple valid house numbers"
+        END
+        CLASS
+            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,4} ?[a-zA-Z]{0,3}( ?[-,]{1} ?[1-9][0-9]{0,4} ?[a-zA-Z]{0,3}){0,12}$')
+            NAME "valid house numbers with optional a-z suffix, optional concatenation separated by comma"
+        END
+        CLASS
+            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,4}/[0-9][1-9]{0,4}( ?[-,]{1} ?[1-9][0-9]{0,4}(/[0-9][1-9]{0,4})?){0,12}$')
+            NAME "valid house numbers with /1 suffix, optional concatenation separated by comma"
+        END
+        CLASS
+            # This class might support conscription numbers in house numbers.
+            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,4} [1-9]/[1-9][0-9]{0,2}( ?[a-zA-Z])?( ?[-,]{1} ?[1-9][0-9]{0,4}( [1-9]/[1-9][0-9]{0,2}( ?[a-z])?)?){0,12}$')
+            NAME "valid house numbers with fractions and optional alphabetic suffix after the fraction (sic!), optional concatenation separated by comma"
         END
         CLASS
             NAME "Nodes/ways with unexpected characters in addr:housenumber=... (allow separation of multiple housenumbers with commas)"

--- a/mapserver/addresses.local.map
+++ b/mapserver/addresses.local.map
@@ -972,16 +972,16 @@ MAP
             NAME "simple valid house numbers"
         END
         CLASS
-            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,4} ?[a-zA-Z]{0,3}( ?[-,]{1} ?[1-9][0-9]{0,4} ?[a-zA-Z]{0,3}){0,12}$')
+            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,4} ?[a-zA-Z]{0,3}( ?[-,] ?[1-9][0-9]{0,4} ?[a-zA-Z]{0,3}){0,12}$')
             NAME "valid house numbers with optional a-z suffix, optional concatenation separated by comma"
         END
         CLASS
-            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,4}/[0-9][1-9]{0,4}( ?[-,]{1} ?[1-9][0-9]{0,4}(/[0-9][1-9]{0,4})?){0,12}$')
+            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,4}(/[1-9][0-9]{0,4})?( ?[-,] ?[1-9][0-9]{0,4}(/[1-9][0-9]{0,4})?){0,12}$')
             NAME "valid house numbers with /1 suffix, optional concatenation separated by comma"
         END
         CLASS
             # This class might support conscription numbers in house numbers.
-            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,4} [1-9]/[1-9][0-9]{0,2}( ?[a-zA-Z])?( ?[-,]{1} ?[1-9][0-9]{0,4}( [1-9]/[1-9][0-9]{0,2}( ?[a-z])?)?){0,12}$')
+            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,4} [1-9]/[1-9][0-9]{0,2}( ?[a-zA-Z])?( ?[-,] ?[1-9][0-9]{0,4}( [1-9]/[1-9][0-9]{0,2}( ?[a-z])?)?){0,12}$')
             NAME "valid house numbers with fractions and optional alphabetic suffix after the fraction (sic!), optional concatenation separated by comma"
         END
         CLASS

--- a/mapserver/addresses.local.map
+++ b/mapserver/addresses.local.map
@@ -940,8 +940,14 @@ MAP
         LABELMAXSCALEDENOM 12500
         LABELMINSCALEDENOM 1
         LABELITEM "houseno"
-        FILTERITEM "houseno"
-        FILTER /[^0-9a-zA-Z ,-]/
+        FILTER ("[houseno]" != '')
+        CLASSITEM "houseno"
+        CLASS
+            # empty class is necessary because the will catch all valid house
+            # numbers and only the invalid ones will hit the next class
+            EXPRESSION /^[1-9][0-9]{0,2} ?[a-zA-Z]{0,3}([-,]*[1-9][0-9]{0,2} ?[a-zA-Z]{0,3}){0,12}$/
+            NAME "valid house numbers"
+        END
         CLASS
             NAME "Nodes/ways with unexpected characters in addr:housenumber=... (allow separation of multiple housenumbers with commas)"
             STYLE

--- a/mapserver/addresses.local.map
+++ b/mapserver/addresses.local.map
@@ -945,7 +945,7 @@ MAP
         CLASS
             # empty class is necessary because the will catch all valid house
             # numbers and only the invalid ones will hit the next class
-            EXPRESSION /^[1-9][0-9]{0,2} ?[a-zA-Z]{0,3}([-,]*[1-9][0-9]{0,2} ?[a-zA-Z]{0,3}){0,12}$/
+            EXPRESSION ('[houseno]' ~ '^[1-9][0-9]{0,2}[ /]?[a-zA-Z]{0,3}([-,]*[1-9][0-9]{0,2}[ /]?[a-zA-Z]{0,3}){0,12}$')
             NAME "valid house numbers"
         END
         CLASS


### PR DESCRIPTION
This implements the regular expressions suggested by @grischard and @ltog in #107 but with modifications to support house numbers used in Württemberg (and partially in Baden): 5/1 instead of 5a.

Accidentially, the regular expression also supports house numbers used in Augsburg 5 1/2, even concatenated with commas.

This pull request closes #107.