### PR TITLE
Report closed interpolations as errors

### DIFF
--- a/osmi/InterpolationWriter.hpp
+++ b/osmi/InterpolationWriter.hpp
@@ -159,9 +159,9 @@ public:
 					(first_taglist.get_value_by_key("addr:country")  != last_taglist.get_value_by_key("addr:country"))  ||
 					(first_taglist.get_value_by_key("addr:full")     != last_taglist.get_value_by_key("addr:full"))     ||
 					(first_taglist.get_value_by_key("addr:place")    != last_taglist.get_value_by_key("addr:place")) ) {
-
 					feature->SetField("error", "different tags on endpoints");
-
+				} else if (way.is_closed()) {
+				    feature->SetField("error", "interpolation is a closed way");
 				} else if ( // no interpolation error
 						(!strcmp(interpolation, "all")) ||
 						(!strcmp(interpolation, "odd")) ||


### PR DESCRIPTION
Fixes #104 

The Mapserver mapfile does not need to be changed because it already catches all errors.