### PR TITLE
Use CRS84 instead of WGS84 to make CRS compatible with GDAL3

### DIFF
--- a/osmi/GeometryHelper.hpp
+++ b/osmi/GeometryHelper.hpp
@@ -13,7 +13,7 @@ class GeometryHelper{
 
 public:
 	GeometryHelper() {
-		m_wgs.SetWellKnownGeogCS("WGS84");
+		m_wgs.SetWellKnownGeogCS("CRS84");
 		m_mercator.importFromEPSG(3857);
 
 		m_wgs2mercator = OGRCreateCoordinateTransformation(&m_wgs, &m_mercator);

--- a/osmi/Writer.hpp
+++ b/osmi/Writer.hpp
@@ -33,7 +33,7 @@ public:
 		}
 
 		OGRSpatialReference spatialref;
-		spatialref.SetWellKnownGeogCS("WGS84");
+		spatialref.SetWellKnownGeogCS("CRS84");
 
 		this->create_layer(m_data_source, geom_type);
 	}
@@ -103,7 +103,7 @@ private:
 
 	void create_layer(GDALDataset* data_source, const OGRwkbGeometryType& geom_type) {
 		OGRSpatialReference sparef;
-		sparef.SetWellKnownGeogCS("WGS84");
+		sparef.SetWellKnownGeogCS("CRS84");
 
 		const char* layer_options[] = { "SPATIAL_INDEX=no", "COMPRESS_GEOM=yes", nullptr };
 


### PR DESCRIPTION
GDAL2 und GDAL3 both do the same thing with "CRS84", but have different
behaviour with "WGS84". This is about axis order. See
https://gdal.org/tutorials/osr_api_tut.html#crs-and-axis-order .