### PR TITLE
Fix tests comparing floating point values

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -60,23 +60,23 @@ error=0
 ./test_engine.pl $1 "Number of entries in ** without value for 'entrance'" "SELECT COUNT(*) FROM ** WHERE entrance IS NULL" "osmi_addresses_entrances" "=" "1"; ((error+=$?))
 ./test_engine.pl $1 "Number of entries in ** with entrance=emergency" "SELECT COUNT(*) FROM ** WHERE entrance=\"emergency\"" "osmi_addresses_entrances" "=" "1"; ((error+=$?))
 
-./test_engine.pl $1 "Minimum occurring length in **" "SELECT MIN(ST_Length(geometry, 0)) FROM **" "osmi_addresses_connection_line" "=" "1.34749447344977"; ((error+=$?))
-./test_engine.pl $1 "Maximum occurring length in **" "SELECT MAX(ST_Length(geometry, 0)) FROM **" "osmi_addresses_connection_line" "=" "17.3055759386695"; ((error+=$?))
+./test_engine.pl $1 "Minimum occurring length in **" "SELECT MIN(ST_Length(geometry, 0)) FROM **" "osmi_addresses_connection_line" "approx" "1.34749447344977"; ((error+=$?))
+./test_engine.pl $1 "Maximum occurring length in **" "SELECT MAX(ST_Length(geometry, 0)) FROM **" "osmi_addresses_connection_line" "approx" "17.3055759386695"; ((error+=$?))
 
-./test_engine.pl $1 "Minimum occurring length in **" "SELECT MIN(ST_Length(geometry, 0)) FROM **" "osmi_addresses_interpolation" "=" "2.81660826175927"; ((error+=$?))
-./test_engine.pl $1 "Maximum occurring length in **" "SELECT MAX(ST_Length(geometry, 0)) FROM **" "osmi_addresses_interpolation" "=" "31.288447031296"; ((error+=$?))
+./test_engine.pl $1 "Minimum occurring length in **" "SELECT MIN(ST_Length(geometry, 0)) FROM **" "osmi_addresses_interpolation" "approx" "2.81660826175927"; ((error+=$?))
+./test_engine.pl $1 "Maximum occurring length in **" "SELECT MAX(ST_Length(geometry, 0)) FROM **" "osmi_addresses_interpolation" "approx" "31.288447031296"; ((error+=$?))
 
-./test_engine.pl $1 "Minimum occurring length in **" "SELECT MIN(ST_Length(geometry, 0)) FROM **" "osmi_addresses_nearest_roads" "=" "16.0156550129829"; ((error+=$?))
-./test_engine.pl $1 "Maximum occurring length in **" "SELECT MAX(ST_Length(geometry, 0)) FROM **" "osmi_addresses_nearest_roads" "=" "139.896459880885"; ((error+=$?))
+./test_engine.pl $1 "Minimum occurring length in **" "SELECT MIN(ST_Length(geometry, 0)) FROM **" "osmi_addresses_nearest_roads" "approx" "16.0156550129829"; ((error+=$?))
+./test_engine.pl $1 "Maximum occurring length in **" "SELECT MAX(ST_Length(geometry, 0)) FROM **" "osmi_addresses_nearest_roads" "approx" "139.896459880885"; ((error+=$?))
 
-./test_engine.pl $1 "Minimum occurring length in **" "SELECT MIN(ST_Length(geometry, 0)) FROM **" "osmi_addresses_ways_with_postal_code" "=" "85.0653586130059"; ((error+=$?))
-./test_engine.pl $1 "Maximum occurring length in **" "SELECT MAX(ST_Length(geometry, 0)) FROM **" "osmi_addresses_ways_with_postal_code" "=" "1932.24220904501"; ((error+=$?))
+./test_engine.pl $1 "Minimum occurring length in **" "SELECT MIN(ST_Length(geometry, 0)) FROM **" "osmi_addresses_ways_with_postal_code" "approx" "85.0653586130059"; ((error+=$?))
+./test_engine.pl $1 "Maximum occurring length in **" "SELECT MAX(ST_Length(geometry, 0)) FROM **" "osmi_addresses_ways_with_postal_code" "approx" "1932.24220904501"; ((error+=$?))
 
-./test_engine.pl $1 "Minimum area in **" "SELECT MIN(ST_Area(ST_Transform(geometry, 2056))) FROM **" "osmi_addresses_ways_with_addresses" "=" "0.958406202423518"; ((error+=$?))
-./test_engine.pl $1 "Maximum area in **" "SELECT MAX(ST_Area(ST_Transform(geometry, 2056))) FROM **" "osmi_addresses_ways_with_addresses" "=" "49.3336374588885"; ((error+=$?))
+./test_engine.pl $1 "Minimum area in **" "SELECT MIN(ST_Area(ST_Transform(geometry, 2056))) FROM **" "osmi_addresses_ways_with_addresses" "approx" "0.958406202423518"; ((error+=$?))
+./test_engine.pl $1 "Maximum area in **" "SELECT MAX(ST_Area(ST_Transform(geometry, 2056))) FROM **" "osmi_addresses_ways_with_addresses" "approx" "49.3336374588885"; ((error+=$?))
 
-./test_engine.pl $1 "Minimum area in **" "SELECT MIN(ST_Area(ST_Transform(geometry, 2056))) FROM **" "osmi_addresses_nearest_areas" "=" "198.809381183972"; ((error+=$?))
-./test_engine.pl $1 "Maximum area in **" "SELECT MAX(ST_Area(ST_Transform(geometry, 2056))) FROM **" "osmi_addresses_nearest_areas" "=" "198.809381183972"; ((error+=$?))
+./test_engine.pl $1 "Minimum area in **" "SELECT MIN(ST_Area(ST_Transform(geometry, 2056))) FROM **" "osmi_addresses_nearest_areas" "approx" "198.809381183972"; ((error+=$?))
+./test_engine.pl $1 "Maximum area in **" "SELECT MAX(ST_Area(ST_Transform(geometry, 2056))) FROM **" "osmi_addresses_nearest_areas" "approx" "198.809381183972"; ((error+=$?))
 
 # color formatting according to http://misc.flogisoft.com/bash/tip_colors_and_formatting
 if [[ "$error" -eq 0 ]]; then

--- a/test/test_engine.pl
+++ b/test/test_engine.pl
@@ -21,7 +21,12 @@ if ($op eq '=') {
 	$result = qx(spatialite "$directory/$file.sqlite" '$query');
 	chomp $result;
 
-	exit &print_result;
+	exit &print_result($result eq $expected);
+} elsif ($op eq 'approx') {
+	$result = qx(spatialite "$directory/$file.sqlite" '$query');
+	chomp $result;
+
+	exit &print_result(abs($result - $expected) < 0.0000001);
 } elsif ($op =~ /bbox/) {
 	my @values = split(';', $query);
 	my $table     = $values[0];
@@ -49,14 +54,14 @@ if ($op eq '=') {
 	$result = qx(spatialite "$directory/$file.sqlite" '$assembled_query');
 	chomp $result;
 
-	exit &print_result;
+	exit &print_result($result eq $expected);
 } else {
 	exit &report_unknown_operator;
 }
 
 # print the test result
 sub print_result {
-	if ($result eq $expected) {
+	if ($_[0]) {
 		print BOLD, GREEN, "PASS: ", RESET, BRIGHT_BLACK, "$name\n", RESET;
 		return 0; # success
 	} else {


### PR DESCRIPTION
The tests were too strict, failing when there were tiny changes between
values. The tests now compare float values by computing the difference
between expected and actual result and making sure it is smaller than
some epsilon.